### PR TITLE
feat: make prisma the source of truth for reputation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /backend/data
 /backend/prisma/dev.db
 /backend/prisma/dev.db-journal
+/backend/prisma/demo.db
+/backend/prisma/demo.db-journal
 
 # pnpm deploy output
 /bundle

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Arbitera is a **trust-minimized, auditable AI escrow and arbitration protocol** for autonomous agents. Agent A queries Agent B's reputation through MCP, decides whether to hire, funds an ERC-20/USDC-compatible escrow, and gets a deterministic AI Judge verdict before the authorized oracle releases payment or refunds the buyer.
 
-> **MVP truth:** reputation currently comes from the backend's append-only verdict index. The response shape is Graph-ready, but this repository does **not** claim a production The Graph subgraph.
+> **MVP truth:** reputation currently comes from Prisma-backed persisted deal records. The response shape is Graph-ready, but this repository does **not** claim a production The Graph subgraph.
 
 ---
 
@@ -95,7 +95,7 @@ The hash commits to the canonical record, including the prompt, rubric, delivera
 1. **Create and fund** — Agent A specifies criteria, seller, deadline, and payment in `ArbiterEscrow`.
 2. **Submit** — Agent B submits a deliverable before the contract deadline.
 3. **Judge** — the backend sends the original task, rubric, and untrusted deliverable to the AI Judge.
-4. **Record** — the backend stores the current deal/verdict projection in SQLite via Prisma and appends the canonical audit record, including score, reasoning, model metadata, raw response, and `verdictHash`, as JSONL.
+4. **Record** — the backend stores the current deal/verdict projection and canonical audit fields in SQLite via Prisma. JSONL remains only an explicit deterministic demo fixture format.
 5. **Settle** — the authorized oracle calls `resolveEscrow` with the verdict hash.
 6. **Reputation** — the settlement record becomes queryable through `GET /api/reputation/:agent` and MCP.
 
@@ -115,11 +115,11 @@ Expected output:
 Arbitra agent hiring decision demo
 MCP source: backend reputation index backed by persisted verdicts
 agent-b: 1/4 successful, 25% success, decision = DO NOT HIRE
-agent-c: 4/4 successful, 100% success, decision = HIRE
+agent-c: 5/5 successful, 100% success, decision = HIRE
 Agent A refuses agent-b and hires agent-c based on returned data.
 ```
 
-The demo launches the backend against [`simulation-agents/data/demo-verdicts.jsonl`](simulation-agents/data/demo-verdicts.jsonl), explicitly selects JSONL persistence so local SQLite state cannot contaminate the fixture, queries the real backend endpoint through the MCP server, and calculates the decision from the returned reputation. Production records use Prisma plus the append-only audit record.
+The demo seeds its explicitly marked fixture records into Prisma, queries the real backend endpoint through the MCP server, calculates the decision from the returned reputation, and verifies a completed audit record through the MCP audit tool. Production records use Prisma as the primary source of truth.
 
 ## 🏗️ Architecture
 
@@ -127,7 +127,7 @@ The demo launches the backend against [`simulation-agents/data/demo-verdicts.jso
 |---|---|---|
 | Smart contract | Solidity `ArbiterEscrow` + OpenZeppelin | Holds ERC-20 funds, enforces state, pays or refunds |
 | AI Judge | TypeScript + LLM chat-completions adapter | Evaluates deliverables against acceptance criteria |
-| Persistence | Prisma + SQLite deal projection, plus canonical JSONL audit record | Keeps current state queryable while preserving the evidence trail |
+| Persistence | Prisma + SQLite persisted deal and canonical audit record | Keeps reputation and audit verification on one source of truth |
 | Oracle integration | Ethers + authorized wallet | Submits `verdictHash` through `resolveEscrow` |
 | Reputation API | Node HTTP server | Aggregates success, failure, recency, category, and history |
 | Agent interface | MCP stdio server | Gives agents structured reputation before hiring |
@@ -158,6 +158,8 @@ The demo launches the backend against [`simulation-agents/data/demo-verdicts.jso
 ```
 
 `GET /api/reputation/:agent` returns judged totals, successes, failures, success/failure rates, recency-weighted reliability, task-category breakdown, and settlement history. The MCP tool `get_agent_reputation` forwards this structured response.
+
+`GET /api/judgments/:dealId` returns the stored canonical evaluation record and a consistency check for its `verdictHash`. This proves that the stored record matches the recorded hash; it does not prove model execution or exactly what the model saw. The MCP tool `verify_deal_verdict` forwards the independent backend verification.
 
 `POST /api/judge-and-settle` runs the same verdict flow and submits the deterministic `verdictHash` to `resolveEscrow`. It requires the `X-Arbitra-Internal-Key` header, configured RPC/escrow/oracle variables, and a bytes32 hex `dealId` for actual on-chain settlement. The legacy `/judge` and `/judge-and-settle` routes remain available for compatibility.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 PORT=3000
+DATABASE_URL=file:./dev.db
 
 LLM_API_KEY=
 LLM_BASE_URL=https://api.openai.com/v1

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,8 +8,9 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "npm run build && mocha",
-    "prisma:generate": "node ../node_modules/prisma/build/index.js generate",
-    "prisma:migrate": "node ../node_modules/prisma/build/index.js migrate dev --name init"
+    "prisma:generate": "set DATABASE_URL=file:./dev.db&& node ../node_modules/prisma/build/index.js generate",
+    "prisma:migrate": "set DATABASE_URL=file:./dev.db&& node ../node_modules/prisma/build/index.js migrate dev --name init",
+    "prisma:deploy": "set DATABASE_URL=file:./dev.db&& node ../node_modules/prisma/build/index.js migrate deploy"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,6 @@
 datasource db {
   provider = "sqlite"
-  url      = "file:./dev.db"
+  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/backend/src/ai-judge/verdict.ts
+++ b/backend/src/ai-judge/verdict.ts
@@ -37,7 +37,7 @@ export interface AuditableVerdict {
   timestamp: string;
 }
 
-function canonicalize(value: unknown): string {
+export function canonicalize(value: unknown): string {
   if (Array.isArray(value)) {
     return `[${value.map(canonicalize).join(",")}]`;
   }
@@ -54,8 +54,56 @@ function canonicalize(value: unknown): string {
   return value === undefined ? "null" : JSON.stringify(value);
 }
 
-function hash(value: unknown): string {
+export function hashCanonicalValue(value: unknown): string {
   return keccak256(toUtf8Bytes(canonicalize(value)));
+}
+
+export interface VerifiableVerdictRecord {
+  dealId: string;
+  buyer?: string;
+  seller?: string;
+  taskCategory?: string;
+  deadline: string;
+  acceptanceCriteria: string[];
+  deliverable: string;
+  approved: boolean;
+  score: number;
+  reasoning: string;
+  verdict: "PASS" | "FAIL";
+  modelId: string;
+  modelVersion: string;
+  evaluationPrompt: string;
+  rawResponse: string;
+  verdictHash: string;
+}
+
+export function calculateVerdictHash(record: VerifiableVerdictRecord): string {
+  const deliverableHash = hashCanonicalValue(record.deliverable);
+  const rubricHash = hashCanonicalValue(record.acceptanceCriteria);
+
+  return hashCanonicalValue({
+    acceptanceCriteria: record.acceptanceCriteria,
+    approved: record.approved,
+    buyer: record.buyer,
+    dealId: record.dealId,
+    deliverable: record.deliverable,
+    deliverableHash,
+    deadline: normalizeDeadline(record.deadline),
+    evaluationPrompt: record.evaluationPrompt,
+    modelId: record.modelId,
+    modelVersion: record.modelVersion,
+    rawResponse: record.rawResponse,
+    reasoning: record.reasoning,
+    rubricHash,
+    score: record.score,
+    seller: record.seller,
+    taskCategory: record.taskCategory,
+    verdict: record.verdict,
+  });
+}
+
+export function verifyVerdictHash(record: VerifiableVerdictRecord): boolean {
+  return calculateVerdictHash(record) === record.verdictHash;
 }
 
 export function normalizeDeadline(deadline: string | number): string {
@@ -87,8 +135,8 @@ export function buildVerdict(
     modelVersion: result.modelVersion ?? configuredModel.modelVersion,
   };
   const normalizedDeadline = normalizeDeadline(input.deadline);
-  const rubricHash = hash(input.acceptanceCriteria);
-  const deliverableHash = hash(input.deliverable);
+  const rubricHash = hashCanonicalValue(input.acceptanceCriteria);
+  const deliverableHash = hashCanonicalValue(input.deliverable);
   const score = result.approved ? 100 : 0;
   const evaluationPrompt = result.evaluationPrompt ?? "";
   const rawResponse = result.rawResponse ?? "";
@@ -118,7 +166,7 @@ export function buildVerdict(
   return {
     ...verdictPayload,
     deadline: normalizedDeadline,
-    verdictHash: hash(verdictPayload),
+    verdictHash: hashCanonicalValue(verdictPayload),
     timestamp: new Date().toISOString(),
   };
 }
@@ -143,6 +191,9 @@ export async function evaluateDeal(
 }
 
 async function persistVerdict(verdict: AuditableVerdict): Promise<void> {
+  // JSONL is retained only as an explicit legacy/demo fixture mode. Prisma is
+  // the application persistence path by default.
+  if (process.env.ARBITRA_PERSISTENCE !== "jsonl") return;
   const filePath =
     process.env.VERDICT_STORE_PATH ?? "backend/data/verdicts.jsonl";
 

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 
+process.env.DATABASE_URL ??= "file:./dev.db";
+
 const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };

--- a/backend/src/persistence.ts
+++ b/backend/src/persistence.ts
@@ -1,6 +1,9 @@
 import type { EscrowDeal } from "@prisma/client";
 
-import type { AuditableVerdict } from "./ai-judge/verdict.js";
+import type {
+  AuditableVerdict,
+  VerifiableVerdictRecord,
+} from "./ai-judge/verdict.js";
 import { prisma } from "./lib/prisma.js";
 
 export type PersistedDeal = Pick<
@@ -25,6 +28,12 @@ export type PersistedDeal = Pick<
   | "createdAt"
   | "updatedAt"
 >;
+
+export type JudgmentRecord = VerifiableVerdictRecord & {
+  timestamp: string;
+  state?: string;
+  resolvedTxHash?: string;
+};
 
 export async function persistVerdict(
   verdict: AuditableVerdict,
@@ -84,7 +93,64 @@ export async function readPersistedDeals(
   sellerAddress: string
 ): Promise<PersistedDeal[]> {
   return prisma.escrowDeal.findMany({
-    where: { sellerAddress },
+    where: { sellerAddress, aiVerdict: { not: null } },
     orderBy: { createdAt: "asc" },
   });
+}
+
+function parseAcceptanceCriteria(criteriaText: string | null): string[] {
+  if (!criteriaText) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(criteriaText);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === "string")
+      ? parsed
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function readPersistedJudgment(
+  dealId: string
+): Promise<JudgmentRecord | null> {
+  const deal = await prisma.escrowDeal.findUnique({ where: { dealId } });
+  if (
+    !deal ||
+    deal.aiVerdict === null ||
+    deal.aiReasoning === null ||
+    deal.aiScore === null ||
+    deal.verdictHash === null ||
+    deal.evaluationPrompt === null ||
+    deal.modelId === null ||
+    deal.modelVersion === null ||
+    deal.rawLlmResponse === null ||
+    deal.deliverableText === null ||
+    deal.deadline === null
+  ) {
+    return null;
+  }
+
+  const acceptanceCriteria = parseAcceptanceCriteria(deal.criteriaText);
+  return {
+    dealId: deal.dealId,
+    buyer: deal.buyerAddress ?? undefined,
+    seller: deal.sellerAddress ?? undefined,
+    taskCategory: deal.taskCategory ?? undefined,
+    deadline: deal.deadline.toISOString(),
+    acceptanceCriteria,
+    deliverable: deal.deliverableText,
+    approved: deal.aiVerdict,
+    score: deal.aiScore,
+    reasoning: deal.aiReasoning,
+    verdict: deal.aiVerdict ? "PASS" : "FAIL",
+    modelId: deal.modelId,
+    modelVersion: deal.modelVersion,
+    evaluationPrompt: deal.evaluationPrompt,
+    rawResponse: deal.rawLlmResponse,
+    verdictHash: deal.verdictHash,
+    timestamp: deal.updatedAt.toISOString(),
+    state: deal.state ?? undefined,
+    resolvedTxHash: deal.resolvedTxHash ?? undefined,
+  };
 }

--- a/backend/src/reputation.ts
+++ b/backend/src/reputation.ts
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-
 import type { AuditableVerdict } from "./ai-judge/verdict.js";
 import { readPersistedDeals } from "./persistence.js";
 
@@ -15,66 +13,26 @@ export interface ReputationSummary {
   history: Array<Pick<AuditableVerdict, "dealId" | "approved" | "score" | "verdictHash" | "timestamp" | "taskCategory">>;
 }
 
-async function readVerdicts(): Promise<AuditableVerdict[]> {
-  const filePath = process.env.VERDICT_STORE_PATH ?? "backend/data/verdicts.jsonl";
-
-  try {
-    const contents = await readFile(filePath, "utf8");
-    return contents
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as AuditableVerdict);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw error;
-  }
-}
-
 export async function getReputation(agent: string): Promise<ReputationSummary> {
-  let records: Array<Pick<AuditableVerdict, "dealId" | "approved" | "score" | "verdictHash" | "timestamp" | "taskCategory"> & { seller?: string }>;
-  try {
-    if (process.env.ARBITRA_PERSISTENCE === "jsonl") {
-      throw new Error("JSONL persistence selected");
-    }
-
-    const deals = await readPersistedDeals(agent);
-    records = deals.map((deal) => ({
-      dealId: deal.dealId,
-      approved: deal.aiVerdict ?? false,
-      score: deal.aiScore ?? 0,
-      verdictHash: deal.verdictHash ?? "",
-      timestamp: deal.updatedAt.toISOString(),
-      taskCategory: deal.taskCategory ?? undefined,
-      seller: deal.sellerAddress ?? undefined,
-    }));
-    const auditRecords = (await readVerdicts()).filter((record) => record.seller === agent);
-    if (records.length) {
-      // Prisma represents the current state of each deal. Keep any additional
-      // canonical JSONL entries as historical judgment events so repeated
-      // evaluations remain visible without creating duplicate deal rows.
-      const seen = new Set<string>();
-      for (const record of auditRecords) {
-        if (!seen.has(record.dealId)) {
-          seen.add(record.dealId);
-          continue;
-        }
-        records.push(record);
-      }
-    } else {
-      records = auditRecords;
-    }
-  } catch {
-    records = (await readVerdicts()).filter((record) => record.seller === agent);
-  }
+  const deals = await readPersistedDeals(agent);
+  const records = deals.map((deal) => ({
+    dealId: deal.dealId,
+    approved: deal.aiVerdict ?? false,
+    score: deal.aiScore ?? 0,
+    verdictHash: deal.verdictHash ?? "",
+    timestamp: deal.updatedAt.toISOString(),
+    taskCategory: deal.taskCategory ?? undefined,
+  }));
   const now = Date.now();
-  const weighted = records.reduce((sum, record) => {
-    const ageDays = Math.max(0, (now - Date.parse(record.timestamp)) / 86_400_000);
-    return sum + (record.approved ? 1 : 0) * Math.exp(-ageDays / 30);
-  }, 0);
-  const weightTotal = records.reduce((sum, record) => {
-    const ageDays = Math.max(0, (now - Date.parse(record.timestamp)) / 86_400_000);
-    return sum + Math.exp(-ageDays / 30);
-  }, 0);
+  const weightFor = (timestamp: string): number => {
+    const ageDays = Math.max(0, (now - Date.parse(timestamp)) / 86_400_000);
+    return Math.exp(-ageDays / 30);
+  };
+  const weighted = records.reduce(
+    (sum, record) => sum + (record.approved ? 1 : 0) * weightFor(record.timestamp),
+    0
+  );
+  const weightTotal = records.reduce((sum, record) => sum + weightFor(record.timestamp), 0);
   const categories: ReputationSummary["byTaskCategory"] = {};
 
   for (const record of records) {
@@ -97,7 +55,6 @@ export async function getReputation(agent: string): Promise<ReputationSummary> {
     failureRate: total ? (total - successes) / total : 0,
     recencyWeightedReliability: weightTotal ? weighted / weightTotal : 0,
     byTaskCategory: categories,
-    history: records.map(({ dealId, approved, score, verdictHash, timestamp, taskCategory }) =>
-      ({ dealId, approved, score, verdictHash, timestamp, taskCategory }))
+    history: records,
   };
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -11,6 +11,8 @@ import {
 import { settleEscrow } from "./oracle.js";
 import { getReputation } from "./reputation.js";
 import { markDealResolved } from "./persistence.js";
+import { readPersistedJudgment } from "./persistence.js";
+import { verifyVerdictHash } from "./ai-judge/verdict.js";
 
 const PORT = Number(process.env.PORT ?? 3000);
 
@@ -250,6 +252,36 @@ export const server = createServer(
         sendJson(response, 200, await getReputation(agent));
       } catch (error) {
         sendJson(response, 500, { error: error instanceof Error ? error.message : "Unable to read reputation" });
+      }
+      return;
+    }
+
+    if (request.method === "GET" && request.url?.startsWith("/api/judgments/")) {
+      let dealId: string;
+      try {
+        const path = new URL(request.url, "http://localhost").pathname;
+        dealId = decodeURIComponent(path.slice("/api/judgments/".length));
+      } catch {
+        sendJson(response, 400, { error: "Deal ID must be URL encoded" });
+        return;
+      }
+
+      if (!dealId.trim()) {
+        sendJson(response, 400, { error: "Deal ID is required" });
+        return;
+      }
+
+      try {
+        const record = await readPersistedJudgment(dealId);
+        if (!record) {
+          sendJson(response, 404, { error: "Judgment not found" });
+          return;
+        }
+        sendJson(response, 200, { ...record, verified: verifyVerdictHash(record) });
+      } catch (error) {
+        sendJson(response, 500, {
+          error: error instanceof Error ? error.message : "Unable to read judgment",
+        });
       }
       return;
     }

--- a/backend/test/judge-api.test.js
+++ b/backend/test/judge-api.test.js
@@ -13,7 +13,7 @@ process.env.LLM_MODEL_VERSION = "test-model-2026-01";
 process.env.VERDICT_STORE_PATH = join(tmpdir(), "arbitra-verdicts-test.jsonl");
 
 const { server } = await import("../dist/server.js");
-const { buildVerdict } = await import("../dist/ai-judge/verdict.js");
+const { buildVerdict, verifyVerdictHash } = await import("../dist/ai-judge/verdict.js");
 const { prisma } = await import("../dist/lib/prisma.js");
 const realFetch = globalThis.fetch;
 let judgeResponse = {
@@ -25,6 +25,7 @@ let judgeResponse = {
 describe("POST /api/judge", function () {
   before(async function () {
     await rm(process.env.VERDICT_STORE_PATH, { force: true });
+    await prisma.escrowDeal.deleteMany({ where: { sellerAddress: "agent-b" } });
     globalThis.fetch = async (input, init) => {
       if (String(input).startsWith("http://llm.test/")) {
         return new Response(
@@ -215,10 +216,36 @@ describe("POST /api/judge", function () {
     const response = await fetch(`http://127.0.0.1:${address.port}/api/reputation/agent-b`);
     const reputation = await response.json();
     assert.equal(response.status, 200);
-    assert.equal(reputation.totalJudged, 3);
-    assert.equal(reputation.successes, 2);
+    assert.equal(reputation.totalJudged, 2);
+    assert.equal(reputation.successes, 1);
     assert.equal(reputation.failures, 1);
-    assert.equal(reputation.successRate, 2 / 3);
-    assert.equal(reputation.byTaskCategory.uncategorized.total, 3);
+    assert.equal(reputation.successRate, 1 / 2);
+    assert.equal(reputation.byTaskCategory.uncategorized.total, 2);
+    assert.ok(reputation.recencyWeightedReliability >= 0);
+    assert.ok(reputation.recencyWeightedReliability <= 1);
+  });
+
+  it("serves and verifies the canonical persisted judgment record", async function () {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/judgments/deal-123`);
+    const record = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(record.dealId, "deal-123");
+    assert.equal(record.acceptanceCriteria[0], "The report contains the requested analysis.");
+    assert.equal(record.deliverable, "The requested analysis is included.");
+    assert.equal(record.modelId, "test-model");
+    assert.equal(record.modelVersion, "test-model-2026-01");
+    assert.equal(record.verified, true);
+    assert.equal(verifyVerdictHash(record), true);
+
+    for (const changed of [
+      { evaluationPrompt: `${record.evaluationPrompt} changed` },
+      { deliverable: `${record.deliverable} changed` },
+      { modelVersion: "tampered-version" },
+      { rawResponse: `${record.rawResponse} changed` },
+    ]) {
+      assert.equal(verifyVerdictHash({ ...record, ...changed }), false);
+    }
   });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -28,8 +28,46 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
           properties: { agent: { type: "string", description: "Seller agent identifier" } },
           required: ["agent"],
         },
+      }, {
+        name: "verify_deal_verdict",
+        description: "Fetch and verify a persisted deal verdict hash through the backend.",
+        inputSchema: {
+          type: "object",
+          properties: { dealId: { type: "string", description: "Deal identifier" } },
+          required: ["dealId"],
+        },
       }],
     });
+    return;
+  }
+
+  if (message.method === "tools/call" && message.params?.name === "verify_deal_verdict") {
+    const dealId = message.params.arguments?.dealId;
+    if (typeof dealId !== "string" || !dealId.trim()) {
+      reply(message.id, { isError: true, content: [{ type: "text", text: "dealId is required" }] });
+      return;
+    }
+    const response = await fetch(`${backendUrl}/api/judgments/${encodeURIComponent(dealId)}`);
+    const data = await response.json() as {
+      verified?: boolean;
+      verdictHash?: string;
+      verdict?: string;
+      score?: number;
+      modelId?: string;
+      modelVersion?: string;
+      [key: string]: unknown;
+    };
+    const result = response.ok
+      ? {
+          verified: data.verified,
+          verdictHash: data.verdictHash,
+          verdict: data.verdict,
+          score: data.score,
+          modelId: data.modelId,
+          modelVersion: data.modelVersion,
+        }
+      : data;
+    reply(message.id, { content: [{ type: "text", text: JSON.stringify(result) }], structuredContent: result, isError: !response.ok });
     return;
   }
 

--- a/mcp-server/test/reputation.test.js
+++ b/mcp-server/test/reputation.test.js
@@ -48,4 +48,42 @@ describe("reputation MCP tool", function () {
     const shouldHire = result.result.structuredContent.successRate >= 0.7;
     assert.equal(shouldHire, false);
   });
+
+  it("verifies a deal verdict through the backend audit endpoint", async function () {
+    const http = createServer((request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({
+        verified: true,
+        verdictHash: "0xabc",
+        verdict: "PASS",
+        score: 100,
+        modelId: "test-model",
+        modelVersion: "test-version",
+      }));
+    });
+    http.listen(0);
+    await once(http, "listening");
+    const address = http.address();
+    assert.ok(address && typeof address !== "string");
+
+    const child = spawn(process.execPath, ["dist/index.js"], {
+      env: { ...process.env, ARBITRA_BACKEND_URL: `http://127.0.0.1:${address.port}` },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const output = [];
+    child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+    child.stdin.end(JSON.stringify({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "verify_deal_verdict", arguments: { dealId: "deal-123" } },
+    }) + "\n");
+    await once(child, "close");
+    await new Promise((resolve) => http.close(resolve));
+
+    const result = JSON.parse(output.join("")).result;
+    assert.equal(result.structuredContent.verified, true);
+    assert.equal(result.structuredContent.verdict, "PASS");
+    assert.equal(result.structuredContent.modelVersion, "test-version");
+  });
 });

--- a/simulation-agents/src/run-court-simulation.ts
+++ b/simulation-agents/src/run-court-simulation.ts
@@ -1,11 +1,94 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const backendPort = Number(process.env.ARBITRA_DEMO_PORT ?? 3317);
 const backendUrl = `http://127.0.0.1:${backendPort}`;
+const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
+process.env.DATABASE_URL = "file:./demo.db";
+execFileSync(process.execPath, [
+  "node_modules/prisma/build/index.js",
+  "migrate",
+  "deploy",
+  "--schema",
+  "backend/prisma/schema.prisma",
+], { cwd: repositoryRoot, stdio: "ignore", env: process.env });
+
+const { buildVerdict } = await import("../../backend/dist/ai-judge/verdict.js");
+const { persistVerdict } = await import("../../backend/dist/persistence.js");
+const { prisma } = await import("../../backend/dist/lib/prisma.js");
 const verdictStorePath = fileURLToPath(
   new URL("../data/demo-verdicts.jsonl", import.meta.url)
 );
+
+async function seedDemoPersistence(): Promise<void> {
+  const fixture = await readFile(verdictStorePath, "utf8");
+  const records = fixture.split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line) as {
+    dealId: string;
+    seller: string;
+    approved: boolean;
+    score: number;
+    verdictHash: string;
+    timestamp: string;
+    taskCategory: string;
+  });
+
+  for (const record of records) {
+    const timestamp = new Date(record.timestamp);
+    await prisma.escrowDeal.upsert({
+      where: { dealId: record.dealId },
+      create: {
+        dealId: record.dealId,
+        sellerAddress: record.seller,
+        criteriaText: JSON.stringify(["Demo fixture judgment"]),
+        deliverableText: record.approved ? "Completed demo deliverable" : "Incomplete demo deliverable",
+        taskCategory: record.taskCategory,
+        deadline: new Date("2099-01-01T00:00:00.000Z"),
+        state: "JUDGED",
+        aiVerdict: record.approved,
+        aiReasoning: "Deterministic demo fixture record.",
+        aiScore: record.score,
+        verdictHash: record.verdictHash,
+        evaluationPrompt: "Demo fixture evaluation prompt",
+        modelId: "demo-fixture",
+        modelVersion: "demo-fixture-1",
+        rawLlmResponse: JSON.stringify({ approved: record.approved }),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      update: {
+        sellerAddress: record.seller,
+        aiVerdict: record.approved,
+        aiScore: record.score,
+        verdictHash: record.verdictHash,
+        taskCategory: record.taskCategory,
+        updatedAt: timestamp,
+      },
+    });
+  }
+
+  const audit = buildVerdict(
+    {
+      dealId: "demo-audit-1",
+      acceptanceCriteria: ["The demo audit record is complete."],
+      deliverable: "The demo audit record is complete.",
+      deadline: "2099-01-01T00:00:00.000Z",
+      seller: "agent-c",
+      taskCategory: "coding",
+    },
+    {
+      approved: true,
+      verdict: "PASS",
+      reasoning: "The demo record satisfies its criterion.",
+      evaluationPrompt: "Demo audit evaluation prompt",
+      rawResponse: JSON.stringify({ approved: true, verdict: "PASS" }),
+      modelId: "demo-model",
+      modelVersion: "demo-model-1",
+    }
+  );
+  await persistVerdict(audit);
+}
 
 interface Reputation {
   agent: string;
@@ -78,11 +161,12 @@ function decisionFor(reputation: Reputation): "HIRE" | "DO NOT HIRE" {
 }
 
 async function main(): Promise<void> {
+  await seedDemoPersistence();
   const backend = start("backend/dist/server.js", [], {
     ...process.env,
     PORT: String(backendPort),
-    VERDICT_STORE_PATH: verdictStorePath,
-    ARBITRA_PERSISTENCE: "jsonl",
+    DATABASE_URL: "file:./demo.db",
+    ARBITRA_PERSISTENCE: "prisma",
     ARBITRA_NO_LISTEN: "false",
   });
 
@@ -104,17 +188,48 @@ async function main(): Promise<void> {
     const agentC = await query("agent-c");
 
     console.log("Arbitra agent hiring decision demo");
-    console.log("MCP source: backend reputation index backed by persisted verdicts");
+    console.log("MCP source: Prisma-backed reputation records");
     for (const reputation of [agentB, agentC]) {
       console.log(
-        `${reputation.agent}: ${reputation.successes}/${reputation.totalJudged} successful, ` +
+        `Agent A → MCP reputation query → ${reputation.agent}: ` +
+          `${reputation.successes}/${reputation.totalJudged} successful, ` +
           `${(reputation.successRate * 100).toFixed(0)}% success, ` +
-          `decision = ${decisionFor(reputation)}`
+          `reasoning = successRate ${reputation.successRate.toFixed(2)} and ` +
+          `recency ${reputation.recencyWeightedReliability.toFixed(2)}; ` +
+          `${decisionFor(reputation)}`
       );
     }
-    console.log("Agent A refuses agent-b and hires agent-c based on returned data.");
+
+    const mcp = start("mcp-server/dist/index.js", [], {
+      ...process.env,
+      ARBITRA_BACKEND_URL: backendUrl,
+    });
+    try {
+      const output = new Promise<string>((resolve, reject) => {
+        const chunks: string[] = [];
+        mcp.stdout.on("data", (chunk: Buffer) => chunks.push(chunk.toString()));
+        mcp.stderr.on("data", (chunk: Buffer) => {
+          const message = chunk.toString().trim();
+          if (message) reject(new Error(message));
+        });
+        mcp.on("error", reject);
+        mcp.on("close", () => resolve(chunks.join("")));
+      });
+      mcp.stdin.end(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "verify_deal_verdict", arguments: { dealId: "demo-audit-1" } },
+      })}\n`);
+      const verification = JSON.parse(await output).result?.structuredContent;
+      console.log(`Deal demo-audit-1 → ${verification.verdict} → ${verification.verdictHash}`);
+      console.log(`Independent verification → ${verification.verified ? "VERIFIED" : "FAILED"}`);
+    } finally {
+      mcp.kill();
+    }
   } finally {
     backend.kill();
+    await prisma.$disconnect();
   }
 }
 


### PR DESCRIPTION
This PR makes Prisma the primary source of truth for reputation and escrow deal persistence.

* Added Prisma + SQLite persistence for escrow deals and AI Judge results
* Moved reputation queries from JSONL to persisted `EscrowDeal` records
* Preserved the existing `judgeDeliverable()` `{ approved: boolean }` contract
* Added auditable verdict persistence including score, model metadata, raw LLM response, and verdict hash
* Added verdict lookup and verification support
* Kept the existing MCP reputation interface compatible
* Stabilized the Agent hiring decision flow
* Added and updated backend/MCP tests
* Kept the AI Court trust boundary explicit and auditable

This keeps the backend persistence layer consistent with the Agent → Reputation → Escrow → AI Judge → Settlement flow.
