### PR TITLE
feat(mcp): integrate Graph-backed agent reputation

### DIFF
--- a/mcp-server/src/data-service.ts
+++ b/mcp-server/src/data-service.ts
@@ -1,5 +1,6 @@
 export interface ReputationRecord {
   agent: string;
+  totalDeals?: number;
   totalJudged: number;
   successes: number;
   failures: number;
@@ -8,7 +9,9 @@ export interface ReputationRecord {
   recencyWeightedReliability?: number;
   byTaskCategory?: Record<string, unknown>;
   history?: unknown[];
+  settlementHistory?: unknown[];
   source: "graph" | "backend";
+  sourceReason?: "graph" | "graph_not_configured" | "graph_empty" | "graph_unavailable" | "graph_invalid";
 }
 
 export interface IndexedDeal {
@@ -28,6 +31,9 @@ export interface IndexedDeal {
   submittedBlockNumber?: string;
   resolvedTransactionHash?: string;
   resolvedBlockNumber?: string;
+  verdictReasoningHash?: string;
+  createdAt?: string;
+  updatedAt?: string;
   source: "graph" | "backend";
 }
 
@@ -36,13 +42,19 @@ interface GraphDeal {
   amount?: unknown; criteriaHash?: unknown; deadline?: unknown; state?: unknown;
   deliverableHash?: unknown; approved?: unknown; createdTransactionHash?: unknown;
   createdBlockNumber?: unknown; submittedTransactionHash?: unknown; submittedBlockNumber?: unknown;
-  resolvedTransactionHash?: unknown; resolvedBlockNumber?: unknown;
+  resolvedTransactionHash?: unknown; resolvedBlockNumber?: unknown; verdictReasoningHash?: unknown;
+  createdAt?: unknown; updatedAt?: unknown;
 }
-interface GraphResponse { data?: { escrows?: unknown[] }; errors?: unknown[] }
+interface GraphResponse { data?: { escrows?: unknown[]; escrow?: unknown }; errors?: unknown[] }
 
 function asString(value: unknown, field: string): string {
   if (typeof value !== "string") throw new Error(`Graph field ${field} is invalid`);
   return value;
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  return asString(value, field);
 }
 
 function mapDeal(value: unknown): IndexedDeal {
@@ -54,14 +66,17 @@ function mapDeal(value: unknown): IndexedDeal {
     token: asString(deal.token, "token"), amount: asString(deal.amount, "amount"),
     criteriaHash: asString(deal.criteriaHash, "criteriaHash"), deadline: asString(deal.deadline, "deadline"),
     state: asString(deal.state, "state"),
-    deliverableHash: deal.deliverableHash === undefined ? undefined : asString(deal.deliverableHash, "deliverableHash"),
-    approved: deal.approved === undefined ? undefined : Boolean(deal.approved),
+    deliverableHash: optionalString(deal.deliverableHash, "deliverableHash"),
+    approved: deal.approved === null || deal.approved === undefined ? undefined : Boolean(deal.approved),
     createdTransactionHash: asString(deal.createdTransactionHash, "createdTransactionHash"),
     createdBlockNumber: asString(deal.createdBlockNumber, "createdBlockNumber"),
-    submittedTransactionHash: deal.submittedTransactionHash === undefined ? undefined : asString(deal.submittedTransactionHash, "submittedTransactionHash"),
-    submittedBlockNumber: deal.submittedBlockNumber === undefined ? undefined : asString(deal.submittedBlockNumber, "submittedBlockNumber"),
-    resolvedTransactionHash: deal.resolvedTransactionHash === undefined ? undefined : asString(deal.resolvedTransactionHash, "resolvedTransactionHash"),
-    resolvedBlockNumber: deal.resolvedBlockNumber === undefined ? undefined : asString(deal.resolvedBlockNumber, "resolvedBlockNumber"),
+    submittedTransactionHash: optionalString(deal.submittedTransactionHash, "submittedTransactionHash"),
+    submittedBlockNumber: optionalString(deal.submittedBlockNumber, "submittedBlockNumber"),
+    resolvedTransactionHash: optionalString(deal.resolvedTransactionHash, "resolvedTransactionHash"),
+    resolvedBlockNumber: optionalString(deal.resolvedBlockNumber, "resolvedBlockNumber"),
+    verdictReasoningHash: optionalString(deal.verdictReasoningHash, "verdictReasoningHash"),
+    createdAt: optionalString(deal.createdAt, "createdAt"),
+    updatedAt: optionalString(deal.updatedAt, "updatedAt"),
     source: "graph",
   };
 }
@@ -77,19 +92,39 @@ export class GraphAdapter {
     });
     if (!response.ok) throw new Error(`Graph request failed: ${response.status}`);
     const data = await response.json() as GraphResponse;
-    if (data.errors?.length || !data.data || !Array.isArray(data.data.escrows)) throw new Error("Graph returned an invalid or empty response");
+    if (data.errors?.length || !data.data) throw new Error("Graph returned an invalid response");
     return data;
   }
 
   async getDeals(agent?: string): Promise<IndexedDeal[]> {
-    const result = await this.query(`query Escrows($seller: Bytes) {
+    const query = agent ? `query Escrows($seller: Bytes!) {
       escrows(where: { seller: $seller }, orderBy: createdBlockNumber, orderDirection: asc) {
-        id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved
+        id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved verdictReasoningHash
         createdTransactionHash createdBlockNumber submittedTransactionHash submittedBlockNumber
-        resolvedTransactionHash resolvedBlockNumber
+        resolvedTransactionHash resolvedBlockNumber createdAt updatedAt
       }
-    }`, { seller: agent?.toLowerCase() });
-    return result.data!.escrows!.map(mapDeal);
+    }` : `query Escrows {
+      escrows(orderBy: createdBlockNumber, orderDirection: asc) {
+        id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved
+        verdictReasoningHash createdTransactionHash createdBlockNumber submittedTransactionHash submittedBlockNumber
+        resolvedTransactionHash resolvedBlockNumber createdAt updatedAt
+      }
+    }`;
+    const result = await this.query(query, agent ? { seller: agent.toLowerCase() } : {});
+    if (!Array.isArray(result.data?.escrows)) throw new Error("Graph returned an invalid escrow list");
+    return result.data.escrows.map(mapDeal);
+  }
+
+  async getDeal(dealId: string): Promise<IndexedDeal | null> {
+    const result = await this.query(`query Escrow($id: ID!) {
+      escrow(id: $id) {
+        id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved verdictReasoningHash
+        createdTransactionHash createdBlockNumber submittedTransactionHash submittedBlockNumber
+        resolvedTransactionHash resolvedBlockNumber createdAt updatedAt
+      }
+    }`, { id: dealId.toLowerCase() });
+    if (result.data?.escrow === null || result.data?.escrow === undefined) return null;
+    return mapDeal(result.data.escrow);
   }
 
   async getReputation(agent: string): Promise<ReputationRecord> {
@@ -98,10 +133,20 @@ export class GraphAdapter {
     const settled = history.filter((deal) => deal.approved !== undefined);
     const successes = settled.filter((deal) => deal.approved).length;
     const totalJudged = settled.length;
-    return { agent, totalJudged, successes, failures: totalJudged - successes,
+    const now = Date.now();
+    const weightFor = (deal: IndexedDeal): number => {
+      const timestamp = deal.updatedAt ?? deal.createdAt;
+      if (!timestamp) return 1;
+      const ageDays = Math.max(0, (now - Number(timestamp) * 1000) / 86_400_000);
+      return Math.exp(-ageDays / 30);
+    };
+    const weightedTotal = settled.reduce((sum, deal) => sum + weightFor(deal), 0);
+    const weightedSuccesses = settled.reduce((sum, deal) => sum + (deal.approved ? weightFor(deal) : 0), 0);
+    return { agent, totalDeals: history.length, totalJudged, successes, failures: totalJudged - successes,
       successRate: totalJudged ? successes / totalJudged : 0,
       failureRate: totalJudged ? (totalJudged - successes) / totalJudged : 0,
-      history, source: "graph" };
+      recencyWeightedReliability: weightedTotal ? weightedSuccesses / weightedTotal : 0,
+      history, settlementHistory: settled, source: "graph", sourceReason: "graph" };
   }
 }
 
@@ -114,20 +159,38 @@ export class ArbiteraDataService {
   ) { if (graphEndpoint?.trim()) this.graph = new GraphAdapter(graphEndpoint, graphApiKey); }
 
   async getReputation(agent: string): Promise<ReputationRecord> {
-    if (this.graph) { try { return await this.graph.getReputation(agent); } catch { /* fallback below */ } }
+    let sourceReason: ReputationRecord["sourceReason"] = this.graph ? "graph_unavailable" : "graph_not_configured";
+    if (this.graph) {
+      try { return await this.graph.getReputation(agent); }
+      catch (error) {
+        if (error instanceof Error && error.message.includes("no escrow history")) sourceReason = "graph_empty";
+        else if (error instanceof TypeError || (error instanceof Error && error.message.includes("Graph request failed"))) sourceReason = "graph_unavailable";
+        else sourceReason = "graph_invalid";
+      }
+    }
     const response = await fetch(`${this.backendUrl}/api/reputation/${encodeURIComponent(agent)}`);
+    if (!response.ok) throw new Error(`Backend reputation request failed: ${response.status}`);
     const data = await response.json() as Omit<ReputationRecord, "source">;
+    return { ...data, source: "backend", sourceReason };
+  }
+
+  async getIndexedDeal(dealId: string): Promise<IndexedDeal | null> {
+    if (!this.graph) return null;
+    return this.graph.getDeal(dealId);
+  }
+
+  async getAudit(dealId: string): Promise<Record<string, unknown>> {
+    const response = await fetch(`${this.backendUrl}/api/judgments/${encodeURIComponent(dealId)}`);
+    if (!response.ok) throw new Error(`Backend audit request failed: ${response.status}`);
+    const data = await response.json() as Record<string, unknown>;
     return { ...data, source: "backend" };
   }
 
   async getDeal(dealId: string): Promise<IndexedDeal | Record<string, unknown>> {
-    if (this.graph) { try {
-      const deals = await this.graph.getDeals();
-      const deal = deals.find((item) => item.dealId === dealId || item.dealId.toLowerCase() === dealId.toLowerCase());
+    try {
+      const deal = await this.getIndexedDeal(dealId);
       if (deal) return deal;
-    } catch { /* fallback below */ } }
-    const response = await fetch(`${this.backendUrl}/api/judgments/${encodeURIComponent(dealId)}`);
-    const data = await response.json() as Record<string, unknown>;
-    return { ...data, source: "backend" };
+    } catch { /* explicit backend fallback below */ }
+    return this.getAudit(dealId);
   }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -57,7 +57,7 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
       reply(message.id, { isError: true, content: [{ type: "text", text: "dealId is required" }] });
       return;
     }
-    const data = await service.getDeal(dealId) as {
+    const data = await service.getAudit(dealId) as {
       verified?: boolean;
       verdictHash?: string;
       verdict?: string;

--- a/mcp-server/test/reputation.test.js
+++ b/mcp-server/test/reputation.test.js
@@ -96,7 +96,7 @@ describe("reputation MCP tool", function () {
       response.end(JSON.stringify({ data: { escrows: [{
         id: "0xdeal", dealId: "0xdeal", buyer: "0xbuyer", seller: "0xseller", token: "0xtoken",
         amount: "100", criteriaHash: "criteria", deadline: "200", state: "ResolvedSuccess",
-        approved: true, createdTransactionHash: "0xcreate", createdBlockNumber: "10",
+        approved: true, verdictReasoningHash: "0xreasoning", createdTransactionHash: "0xcreate", createdBlockNumber: "10",
         submittedTransactionHash: "0xsubmit", submittedBlockNumber: "11",
         resolvedTransactionHash: "0xresolve", resolvedBlockNumber: "12",
       }] } }));
@@ -118,8 +118,10 @@ describe("reputation MCP tool", function () {
 
     const result = JSON.parse(output.join("")).result.structuredContent;
     assert.equal(result.source, "graph");
+    assert.equal(result.sourceReason, "graph");
     assert.equal(result.successRate, 1);
     assert.equal(result.history[0].resolvedTransactionHash, "0xresolve");
+    assert.equal(result.history[0].verdictReasoningHash, "0xreasoning");
   });
 
   it("falls back to the backend when Graph is empty or malformed", async function () {
@@ -150,6 +152,32 @@ describe("reputation MCP tool", function () {
 
     const result = JSON.parse(output.join("")).result.structuredContent;
     assert.equal(result.source, "backend");
+    assert.equal(result.sourceReason, "graph_empty");
     assert.equal(result.totalJudged, 1);
+  });
+
+  it("labels an unreachable Graph endpoint when using backend fallback", async function () {
+    const backend = createServer((request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ agent: "agent-b", totalJudged: 0, successes: 0, failures: 0, successRate: 0, failureRate: 0 }));
+    });
+    backend.listen(0);
+    await once(backend, "listening");
+    const address = backend.address();
+    assert.ok(address && typeof address !== "string");
+
+    const child = spawn(process.execPath, ["dist/index.js"], {
+      env: { ...process.env, GRAPH_ENDPOINT: "http://127.0.0.1:1", ARBITRA_BACKEND_URL: `http://127.0.0.1:${address.port}` },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const output = [];
+    child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+    child.stdin.end(JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "get_agent_reputation", arguments: { agent: "agent-b" } } }) + "\n");
+    await once(child, "close");
+    await new Promise((resolve) => backend.close(resolve));
+
+    const result = JSON.parse(output.join(""));
+    assert.equal(result.result.structuredContent.source, "backend");
+    assert.equal(result.result.structuredContent.sourceReason, "graph_unavailable");
   });
 });

--- a/simulation-agents/src/run-court-simulation.ts
+++ b/simulation-agents/src/run-court-simulation.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { execFileSync } from "node:child_process";
+import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -90,6 +91,42 @@ async function seedDemoPersistence(): Promise<void> {
   await persistVerdict(audit);
 }
 
+function startMockGraph(records: Array<{ dealId: string; seller: string; approved: boolean; timestamp: string }>) {
+  const graph = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    const variables = JSON.parse(body).variables as { seller?: string } | undefined;
+    const seller = variables?.seller?.toLowerCase();
+    const escrows = records
+      .filter((record) => !seller || record.seller.toLowerCase() === seller)
+      .map((record, index) => ({
+        id: record.dealId,
+        dealId: record.dealId,
+        buyer: "agent-a",
+        seller: record.seller,
+        token: "demo-token",
+        amount: "100",
+        criteriaHash: "demo-criteria",
+        deadline: "4102444800",
+        state: record.approved ? "ResolvedSuccess" : "ResolvedRefund",
+        deliverableHash: "demo-deliverable",
+        approved: record.approved,
+        verdictReasoningHash: `demo-reasoning-${record.dealId}`,
+        createdTransactionHash: `demo-create-${index}`,
+        createdBlockNumber: String(index + 1),
+        submittedTransactionHash: `demo-submit-${index}`,
+        submittedBlockNumber: String(index + 2),
+        resolvedTransactionHash: `demo-resolve-${index}`,
+        resolvedBlockNumber: String(index + 3),
+        createdAt: String(Math.floor(Date.parse(record.timestamp) / 1000)),
+        updatedAt: String(Math.floor(Date.parse(record.timestamp) / 1000)),
+      }));
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify({ data: { escrows, escrow: escrows[0] ?? null } }));
+  });
+  return graph;
+}
+
 interface Reputation {
   agent: string;
   totalJudged: number;
@@ -162,12 +199,25 @@ function decisionFor(reputation: Reputation): "HIRE" | "DO NOT HIRE" {
 
 async function main(): Promise<void> {
   await seedDemoPersistence();
+  const fixture = (await readFile(verdictStorePath, "utf8"))
+    .split(/\r?\n/).filter(Boolean)
+    .map((line) => JSON.parse(line) as { dealId: string; seller: string; approved: boolean; timestamp: string });
+  const graph = startMockGraph(fixture);
+  graph.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve) => graph.once("listening", () => resolve()));
+  const graphAddress = graph.address();
+  if (!graphAddress || typeof graphAddress === "string") throw new Error("Mock Graph did not start");
   const backend = start("backend/dist/server.js", [], {
     ...process.env,
     PORT: String(backendPort),
     DATABASE_URL: "file:./demo.db",
     ARBITRA_PERSISTENCE: "prisma",
     ARBITRA_NO_LISTEN: "false",
+    // The demo only reads Prisma and does not submit blockchain transactions.
+    // These syntactically valid placeholders keep the backend's blockchain
+    // listener initialization from terminating the local audit demo.
+    ARBITER_ESCROW_ADDRESS: "0x0000000000000000000000000000000000000001",
+    ARBITER_ORACLE_PRIVATE_KEY: "0x1111111111111111111111111111111111111111111111111111111111111111",
   });
 
   try {
@@ -176,6 +226,7 @@ async function main(): Promise<void> {
       const mcp = start("mcp-server/dist/index.js", [], {
         ...process.env,
         ARBITRA_BACKEND_URL: backendUrl,
+        GRAPH_ENDPOINT: `http://127.0.0.1:${graphAddress.port}`,
       });
       try {
         return await queryMcp(mcp, agent);
@@ -188,7 +239,7 @@ async function main(): Promise<void> {
     const agentC = await query("agent-c");
 
     console.log("Arbitra agent hiring decision demo");
-    console.log("MCP source: Prisma-backed reputation records");
+    console.log("MCP source: local Graph adapter backed by deterministic escrow fixtures");
     for (const reputation of [agentB, agentC]) {
       console.log(
         `Agent A → MCP reputation query → ${reputation.agent}: ` +
@@ -229,6 +280,7 @@ async function main(): Promise<void> {
     }
   } finally {
     backend.kill();
+    await new Promise<void>((resolve) => graph.close(() => resolve()));
     await prisma.$disconnect();
   }
 }


### PR DESCRIPTION
## Summary

Integrates the existing The Graph subgraph with the MCP server to provide agents with Graph-backed reputation and on-chain escrow evidence.

## Changes

* Added reusable Graph-backed data access through `GraphAdapter` and `ArbitraDataService`.
* Extended agent reputation data with:

  * total deals
  * successful/failed settlements
  * success rate
  * recency-weighted reliability
  * settlement history
  * indexed escrow evidence
  * `verdictReasoningHash`
  * source labels
* Added direct escrow lookup support.
* Added explicit Graph states for empty, unavailable, invalid, and not-configured data.
* Preserved unresolved Graph records with `approved: null`.
* Kept `verify_deal_verdict` backed by the existing backend/Prisma audit data.
* Extended the agent simulation to demonstrate reputation-based hiring decisions:

  * Agent B → DO NOT HIRE
  * Agent C → HIRE
* No frontend, smart contract, subgraph source, or AI Judge/IPFS code was modified.

## Validation

* MCP tests: 5 passing
* Backend tests: 11 passing
* Backend build: passed
* MCP build: passed
* Agent simulation: passed
* `git diff --check`: passed

The integration is designed around the core Arbitra flow:

**Agent → MCP → The Graph → Reputation → HIRE / DO NOT HIRE**
