### PR TITLE
fix: harden Arbitra end-to-end demo flow

### DIFF
--- a/backend/src/services/escrowManager.ts
+++ b/backend/src/services/escrowManager.ts
@@ -1,17 +1,27 @@
-import { ethers } from 'ethers';
 import * as dotenv from 'dotenv';
 import { PrismaClient } from '@prisma/client';
-import { judgeDeliverable } from '../ai-judge/judge.js';
+import { evaluateDeal } from '../ai-judge/verdict.js';
 import { escrowContract, txQueue } from '../blockchain/contractClient.js';
 
 dotenv.config();
 
-const MODEL_ID = process.env.LLM_MODEL || "gpt-4o-mini";
 export const prisma = new PrismaClient();
 export const processedDealsInSession = new Set<string>();
 
+function parseAcceptanceCriteria(criteriaText: string): string[] {
+    try {
+        const parsed: unknown = JSON.parse(criteriaText);
+        if (Array.isArray(parsed) && parsed.every((item) => typeof item === 'string' && item.trim())) {
+            return parsed;
+        }
+    } catch {
+        // The on-chain criteria field may be a plain hash/string in fallback mode.
+    }
+    return [criteriaText];
+}
+
 // ---------------------------------------------------------------------------
-// 2. CORE SETTLEMENT LOGIC (AI Judgment + Attestation Hash + On-Chain Tx)
+// 2. CORE SETTLEMENT LOGIC (AI Judgment + Canonical Verdict Hash + On-Chain Tx)
 // ---------------------------------------------------------------------------
 export async function processDealSettlement(dealId: string, deliverableHash: string) {
     if (processedDealsInSession.has(dealId)) {
@@ -47,22 +57,21 @@ export async function processDealSettlement(dealId: string, deliverableHash: str
         console.log(`📦 Deliverable: "${deliverableText.slice(0, 80)}..."`);
 
         // Step C: Trigger the AI Judge Engine
-        console.log(`🤖 Invoking AI Judge Engine (${MODEL_ID})...`);
-        const verdict = await judgeDeliverable({
-            task: "Escrow Deliverable Evaluation",
-            acceptanceCriteria: criteriaText,
-            deliverable: deliverableText
+        console.log(`🤖 Invoking AI Judge Engine...`);
+        const verdict = await evaluateDeal({
+            dealId,
+            acceptanceCriteria: parseAcceptanceCriteria(criteriaText),
+            deliverable: deliverableText,
+            deadline: Number(onChainDeal.deadline),
+            buyer: onChainDeal.buyer,
+            seller: onChainDeal.seller,
         });
 
         console.log(`⚖️  Judge Verdict: ${verdict.approved ? '✅ APPROVED' : '❌ REJECTED'}`);
         console.log(`📝 Reason: ${verdict.reasoning}`);
 
-        // Step D: Generate Cryptographic Attestation Hash
-        const attestationHash = ethers.solidityPackedKeccak256(
-            ['string', 'string', 'string', 'bool'],
-            [criteriaText, deliverableText, MODEL_ID, verdict.approved]
-        );
-        console.log(`🔒 Attestation Hash: ${attestationHash}`);
+        // The canonical verdict hash is also the on-chain audit reference.
+        console.log(`🔒 Verdict Hash: ${verdict.verdictHash}`);
 
         // Step E: Enqueue On-Chain Transaction Execution (Serialized Nonces)
         await txQueue.enqueue(async () => {
@@ -71,7 +80,7 @@ export async function processDealSettlement(dealId: string, deliverableHash: str
             const tx = await escrowContract.resolveEscrow(
                 dealId,
                 verdict.approved,
-                attestationHash
+                verdict.verdictHash
             );
             console.log(`🚀 Tx Broadcasted: ${tx.hash}. Waiting for block inclusion...`);
             
@@ -85,7 +94,7 @@ export async function processDealSettlement(dealId: string, deliverableHash: str
                     state: verdict.approved ? 'ResolvedSuccess' : 'ResolvedRefund',
                     aiVerdict: verdict.approved,
                     aiReasoning: verdict.reasoning,
-                    verdictHash: attestationHash,
+                    verdictHash: verdict.verdictHash,
                     resolvedTxHash: tx.hash
                 }
             }).catch(() => {

--- a/mcp-server/src/data-service.ts
+++ b/mcp-server/src/data-service.ts
@@ -37,6 +37,30 @@ export interface IndexedDeal {
   source: "graph" | "backend";
 }
 
+export type GraphSourceReason =
+  | "graph"
+  | "graph_not_configured"
+  | "graph_empty"
+  | "graph_unavailable"
+  | "graph_invalid";
+
+const DEFAULT_GRAPH_TIMEOUT_MS = 5_000;
+
+export class GraphUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GraphUnavailableError";
+  }
+}
+
+export function normalizeIdentifier(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized || /\s/.test(normalized)) {
+    throw new Error(`${field} must be a non-empty identifier`);
+  }
+  return normalized;
+}
+
 interface GraphDeal {
   id?: unknown; dealId?: unknown; buyer?: unknown; seller?: unknown; token?: unknown;
   amount?: unknown; criteriaHash?: unknown; deadline?: unknown; state?: unknown;
@@ -48,13 +72,30 @@ interface GraphDeal {
 interface GraphResponse { data?: { escrows?: unknown[]; escrow?: unknown }; errors?: unknown[] }
 
 function asString(value: unknown, field: string): string {
-  if (typeof value !== "string") throw new Error(`Graph field ${field} is invalid`);
+  if (typeof value !== "string" || !value.trim()) throw new Error(`Graph field ${field} is invalid`);
   return value;
+}
+
+function asIntegerString(value: unknown, field: string): string {
+  const stringValue = asString(value, field);
+  if (!/^\d+$/.test(stringValue)) throw new Error(`Graph field ${field} is invalid`);
+  return stringValue;
 }
 
 function optionalString(value: unknown, field: string): string | undefined {
   if (value === null || value === undefined) return undefined;
   return asString(value, field);
+}
+
+function optionalIntegerString(value: unknown, field: string): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  return asIntegerString(value, field);
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== "boolean") throw new Error(`Graph field ${field} is invalid`);
+  return value;
 }
 
 function mapDeal(value: unknown): IndexedDeal {
@@ -63,41 +104,63 @@ function mapDeal(value: unknown): IndexedDeal {
   return {
     dealId: asString(deal.dealId ?? deal.id, "dealId"),
     buyer: asString(deal.buyer, "buyer"), seller: asString(deal.seller, "seller"),
-    token: asString(deal.token, "token"), amount: asString(deal.amount, "amount"),
-    criteriaHash: asString(deal.criteriaHash, "criteriaHash"), deadline: asString(deal.deadline, "deadline"),
+    token: asString(deal.token, "token"), amount: asIntegerString(deal.amount, "amount"),
+    criteriaHash: asString(deal.criteriaHash, "criteriaHash"), deadline: asIntegerString(deal.deadline, "deadline"),
     state: asString(deal.state, "state"),
     deliverableHash: optionalString(deal.deliverableHash, "deliverableHash"),
-    approved: deal.approved === null || deal.approved === undefined ? undefined : Boolean(deal.approved),
+    approved: optionalBoolean(deal.approved, "approved"),
     createdTransactionHash: asString(deal.createdTransactionHash, "createdTransactionHash"),
-    createdBlockNumber: asString(deal.createdBlockNumber, "createdBlockNumber"),
+    createdBlockNumber: asIntegerString(deal.createdBlockNumber, "createdBlockNumber"),
     submittedTransactionHash: optionalString(deal.submittedTransactionHash, "submittedTransactionHash"),
-    submittedBlockNumber: optionalString(deal.submittedBlockNumber, "submittedBlockNumber"),
+    submittedBlockNumber: optionalIntegerString(deal.submittedBlockNumber, "submittedBlockNumber"),
     resolvedTransactionHash: optionalString(deal.resolvedTransactionHash, "resolvedTransactionHash"),
-    resolvedBlockNumber: optionalString(deal.resolvedBlockNumber, "resolvedBlockNumber"),
+    resolvedBlockNumber: optionalIntegerString(deal.resolvedBlockNumber, "resolvedBlockNumber"),
     verdictReasoningHash: optionalString(deal.verdictReasoningHash, "verdictReasoningHash"),
-    createdAt: optionalString(deal.createdAt, "createdAt"),
-    updatedAt: optionalString(deal.updatedAt, "updatedAt"),
+    createdAt: optionalIntegerString(deal.createdAt, "createdAt"),
+    updatedAt: optionalIntegerString(deal.updatedAt, "updatedAt"),
     source: "graph",
   };
 }
 
 export class GraphAdapter {
-  constructor(private readonly endpoint: string, private readonly apiKey?: string) {}
+  constructor(
+    private readonly endpoint: string,
+    private readonly apiKey?: string,
+    private readonly timeoutMs = DEFAULT_GRAPH_TIMEOUT_MS,
+    private readonly clock: () => number = Date.now,
+  ) {}
 
   private async query(query: string, variables: Record<string, unknown>): Promise<GraphResponse> {
-    const response = await fetch(this.endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}) },
-      body: JSON.stringify({ query, variables }),
-    });
-    if (!response.ok) throw new Error(`Graph request failed: ${response.status}`);
-    const data = await response.json() as GraphResponse;
-    if (data.errors?.length || !data.data) throw new Error("Graph returned an invalid response");
-    return data;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(this.endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}) },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new GraphUnavailableError(`Graph request failed: ${response.status}`);
+      let data: GraphResponse;
+      try {
+        data = await response.json() as GraphResponse;
+      } catch {
+        throw new Error("Graph returned invalid JSON");
+      }
+      if (!data || data.errors?.length || !data.data || typeof data.data !== "object") throw new Error("Graph returned an invalid response");
+      return data;
+    } catch (error) {
+      if (error instanceof GraphUnavailableError || (error instanceof Error && error.message.startsWith("Graph returned"))) throw error;
+      const timedOut = controller.signal.aborted || (error instanceof DOMException && error.name === "AbortError");
+      throw new GraphUnavailableError(`Graph request ${timedOut ? "timed out" : "is unavailable"}`);
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   async getDeals(agent?: string): Promise<IndexedDeal[]> {
-    const query = agent ? `query Escrows($seller: Bytes!) {
+    const normalizedAgent = agent === undefined ? undefined : normalizeIdentifier(agent, "agent");
+    const query = normalizedAgent ? `query Escrows($seller: Bytes!) {
       escrows(where: { seller: $seller }, orderBy: createdBlockNumber, orderDirection: asc) {
         id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved verdictReasoningHash
         createdTransactionHash createdBlockNumber submittedTransactionHash submittedBlockNumber
@@ -110,39 +173,44 @@ export class GraphAdapter {
         resolvedTransactionHash resolvedBlockNumber createdAt updatedAt
       }
     }`;
-    const result = await this.query(query, agent ? { seller: agent.toLowerCase() } : {});
+    const result = await this.query(query, normalizedAgent ? { seller: normalizedAgent.toLowerCase() } : {});
     if (!Array.isArray(result.data?.escrows)) throw new Error("Graph returned an invalid escrow list");
     return result.data.escrows.map(mapDeal);
   }
 
   async getDeal(dealId: string): Promise<IndexedDeal | null> {
+    const normalizedDealId = normalizeIdentifier(dealId, "dealId");
     const result = await this.query(`query Escrow($id: ID!) {
       escrow(id: $id) {
         id dealId buyer seller token amount criteriaHash deadline state deliverableHash approved verdictReasoningHash
         createdTransactionHash createdBlockNumber submittedTransactionHash submittedBlockNumber
         resolvedTransactionHash resolvedBlockNumber createdAt updatedAt
       }
-    }`, { id: dealId.toLowerCase() });
+    }`, { id: normalizedDealId.toLowerCase() });
     if (result.data?.escrow === null || result.data?.escrow === undefined) return null;
     return mapDeal(result.data.escrow);
   }
 
   async getReputation(agent: string): Promise<ReputationRecord> {
-    const history = await this.getDeals(agent);
+    const normalizedAgent = normalizeIdentifier(agent, "agent");
+    const history = await this.getDeals(normalizedAgent);
     if (history.length === 0) throw new Error("Graph returned no escrow history");
     const settled = history.filter((deal) => deal.approved !== undefined);
-    const successes = settled.filter((deal) => deal.approved).length;
+    const successes = settled.filter((deal) => deal.approved === true).length;
     const totalJudged = settled.length;
-    const now = Date.now();
+    const now = this.clock();
     const weightFor = (deal: IndexedDeal): number => {
       const timestamp = deal.updatedAt ?? deal.createdAt;
       if (!timestamp) return 1;
-      const ageDays = Math.max(0, (now - Number(timestamp) * 1000) / 86_400_000);
-      return Math.exp(-ageDays / 30);
+      const timestampMs = Number(timestamp) * 1000;
+      if (!Number.isFinite(timestampMs)) return 1;
+      const ageDays = Math.max(0, (now - timestampMs) / 86_400_000);
+      const weight = Math.exp(-ageDays / 30);
+      return Number.isFinite(weight) && weight >= 0 ? weight : 1;
     };
     const weightedTotal = settled.reduce((sum, deal) => sum + weightFor(deal), 0);
-    const weightedSuccesses = settled.reduce((sum, deal) => sum + (deal.approved ? weightFor(deal) : 0), 0);
-    return { agent, totalDeals: history.length, totalJudged, successes, failures: totalJudged - successes,
+    const weightedSuccesses = settled.reduce((sum, deal) => sum + (deal.approved === true ? weightFor(deal) : 0), 0);
+    return { agent: normalizedAgent, totalDeals: history.length, totalJudged, successes, failures: totalJudged - successes,
       successRate: totalJudged ? successes / totalJudged : 0,
       failureRate: totalJudged ? (totalJudged - successes) / totalJudged : 0,
       recencyWeightedReliability: weightedTotal ? weightedSuccesses / weightedTotal : 0,
@@ -156,19 +224,22 @@ export class ArbiteraDataService {
     private readonly backendUrl = process.env.ARBITRA_BACKEND_URL ?? "http://localhost:3000",
     graphEndpoint = process.env.GRAPH_ENDPOINT,
     graphApiKey = process.env.GRAPH_API_KEY,
-  ) { if (graphEndpoint?.trim()) this.graph = new GraphAdapter(graphEndpoint, graphApiKey); }
+    graphTimeoutMs = DEFAULT_GRAPH_TIMEOUT_MS,
+    clock: () => number = Date.now,
+  ) { if (graphEndpoint?.trim()) this.graph = new GraphAdapter(graphEndpoint, graphApiKey, graphTimeoutMs, clock); }
 
   async getReputation(agent: string): Promise<ReputationRecord> {
+    const normalizedAgent = normalizeIdentifier(agent, "agent");
     let sourceReason: ReputationRecord["sourceReason"] = this.graph ? "graph_unavailable" : "graph_not_configured";
     if (this.graph) {
-      try { return await this.graph.getReputation(agent); }
+      try { return await this.graph.getReputation(normalizedAgent); }
       catch (error) {
         if (error instanceof Error && error.message.includes("no escrow history")) sourceReason = "graph_empty";
-        else if (error instanceof TypeError || (error instanceof Error && error.message.includes("Graph request failed"))) sourceReason = "graph_unavailable";
+        else if (error instanceof GraphUnavailableError || error instanceof TypeError) sourceReason = "graph_unavailable";
         else sourceReason = "graph_invalid";
       }
     }
-    const response = await fetch(`${this.backendUrl}/api/reputation/${encodeURIComponent(agent)}`);
+    const response = await fetch(`${this.backendUrl}/api/reputation/${encodeURIComponent(normalizedAgent)}`);
     if (!response.ok) throw new Error(`Backend reputation request failed: ${response.status}`);
     const data = await response.json() as Omit<ReputationRecord, "source">;
     return { ...data, source: "backend", sourceReason };
@@ -176,21 +247,27 @@ export class ArbiteraDataService {
 
   async getIndexedDeal(dealId: string): Promise<IndexedDeal | null> {
     if (!this.graph) return null;
-    return this.graph.getDeal(dealId);
+    return this.graph.getDeal(normalizeIdentifier(dealId, "dealId"));
   }
 
-  async getAudit(dealId: string): Promise<Record<string, unknown>> {
-    const response = await fetch(`${this.backendUrl}/api/judgments/${encodeURIComponent(dealId)}`);
+  async getAudit(dealId: string, sourceReason?: GraphSourceReason): Promise<Record<string, unknown>> {
+    const normalizedDealId = normalizeIdentifier(dealId, "dealId");
+    const response = await fetch(`${this.backendUrl}/api/judgments/${encodeURIComponent(normalizedDealId)}`);
     if (!response.ok) throw new Error(`Backend audit request failed: ${response.status}`);
     const data = await response.json() as Record<string, unknown>;
-    return { ...data, source: "backend" };
+    return { ...data, source: "backend", ...(sourceReason ? { sourceReason } : {}) };
   }
 
   async getDeal(dealId: string): Promise<IndexedDeal | Record<string, unknown>> {
+    const normalizedDealId = normalizeIdentifier(dealId, "dealId");
+    let sourceReason: GraphSourceReason = this.graph ? "graph_unavailable" : "graph_not_configured";
     try {
-      const deal = await this.getIndexedDeal(dealId);
+      const deal = await this.getIndexedDeal(normalizedDealId);
       if (deal) return deal;
-    } catch { /* explicit backend fallback below */ }
-    return this.getAudit(dealId);
+      sourceReason = "graph_empty";
+    } catch (error) {
+      sourceReason = error instanceof GraphUnavailableError ? "graph_unavailable" : "graph_invalid";
+    }
+    return this.getAudit(normalizedDealId, sourceReason);
   }
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,6 +8,14 @@ function reply(id: unknown, result: unknown): void {
   process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
 }
 
+function protocolError(id: unknown, code: number, message: string): void {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } })}\n`);
+}
+
+function toolError(id: unknown, message: string): void {
+  reply(id, { isError: true, content: [{ type: "text", text: message }], structuredContent: { error: message } });
+}
+
 async function handle(message: { id?: unknown; method?: string; params?: any }): Promise<void> {
   if (message.method === "initialize") {
     reply(message.id, {
@@ -54,7 +62,7 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
   if (message.method === "tools/call" && message.params?.name === "verify_deal_verdict") {
     const dealId = message.params.arguments?.dealId;
     if (typeof dealId !== "string" || !dealId.trim()) {
-      reply(message.id, { isError: true, content: [{ type: "text", text: "dealId is required" }] });
+      toolError(message.id ?? null, "dealId is required");
       return;
     }
     const data = await service.getAudit(dealId) as {
@@ -78,7 +86,7 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
   if (message.method === "tools/call" && message.params?.name === "get_agent_reputation") {
     const agent = message.params.arguments?.agent;
     if (typeof agent !== "string" || !agent.trim()) {
-      reply(message.id, { isError: true, content: [{ type: "text", text: "agent is required" }] });
+      toolError(message.id ?? null, "agent is required");
       return;
     }
     const data = await service.getReputation(agent);
@@ -89,7 +97,7 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
   if (message.method === "tools/call" && message.params?.name === "get_indexed_deal") {
     const dealId = message.params.arguments?.dealId;
     if (typeof dealId !== "string" || !dealId.trim()) {
-      reply(message.id, { isError: true, content: [{ type: "text", text: "dealId is required" }] });
+      toolError(message.id ?? null, "dealId is required");
       return;
     }
     const data = await service.getDeal(dealId);
@@ -97,15 +105,33 @@ async function handle(message: { id?: unknown; method?: string; params?: any }):
     return;
   }
 
-  reply(message.id, { isError: true, content: [{ type: "text", text: `Unknown method: ${message.method}` }] });
+  if (message.method === "tools/call") {
+    toolError(message.id ?? null, `Unknown tool: ${message.params?.name ?? "undefined"}`);
+    return;
+  }
+
+  protocolError(message.id ?? null, -32601, `Unknown method: ${message.method}`);
+}
+
+async function handleLine(line: string): Promise<void> {
+  let message: { id?: unknown; method?: string; params?: any };
+  try {
+    message = JSON.parse(line) as { id?: unknown; method?: string; params?: any };
+  } catch {
+    protocolError(null, -32700, "Parse error");
+    return;
+  }
+  try {
+    await handle(message);
+  } catch (error) {
+    toolError(message.id ?? null, error instanceof Error ? error.message : "Tool execution failed");
+  }
 }
 
 const input = createInterface({ input: process.stdin });
 const pending = new Set<Promise<void>>();
 input.on("line", (line) => {
-  const task = handle(JSON.parse(line)).catch((error) => {
-    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
-  });
+  const task = handleLine(line);
   pending.add(task);
   void task.finally(() => pending.delete(task));
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -121,6 +121,10 @@ async function handleLine(line: string): Promise<void> {
     protocolError(null, -32700, "Parse error");
     return;
   }
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    protocolError(null, -32600, "Invalid Request");
+    return;
+  }
   try {
     await handle(message);
   } catch (error) {

--- a/mcp-server/test/data-service.test.js
+++ b/mcp-server/test/data-service.test.js
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { describe, it } from "mocha";
+import { GraphAdapter, GraphUnavailableError } from "../dist/data-service.js";
+
+function deal(overrides = {}) {
+  return {
+    id: "0xdeal",
+    dealId: "0xdeal",
+    buyer: "0xbuyer",
+    seller: "0xseller",
+    token: "0xtoken",
+    amount: "100",
+    criteriaHash: "criteria",
+    deadline: "200",
+    state: "ResolvedRefund",
+    deliverableHash: null,
+    approved: false,
+    createdTransactionHash: "0xcreate",
+    createdBlockNumber: "10",
+    submittedTransactionHash: "0xsubmit",
+    submittedBlockNumber: "11",
+    resolvedTransactionHash: "0xresolve",
+    resolvedBlockNumber: "12",
+    verdictReasoningHash: "0xreasoning",
+    createdAt: "1000",
+    updatedAt: "1000",
+    ...overrides,
+  };
+}
+
+async function graphServer(payload, delay = 0) {
+  const server = createServer(async (request, response) => {
+    if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+    response.statusCode = payload.status ?? 200;
+    response.setHeader("Content-Type", "application/json");
+    if (payload.body !== undefined) response.end(payload.body);
+    else response.end(JSON.stringify(payload.json ?? { data: { escrows: [deal()] } }));
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address && typeof address !== "string");
+  return { server, endpoint: `http://127.0.0.1:${address.port}` };
+}
+
+describe("GraphAdapter validation and reliability", function () {
+  it("accepts real booleans and rejects string booleans", async function () {
+    const valid = await graphServer({ json: { data: { escrows: [deal({ approved: true })] } } });
+    const adapter = new GraphAdapter(valid.endpoint);
+    assert.equal((await adapter.getDeals("0xseller"))[0].approved, true);
+    await new Promise((resolve) => valid.server.close(resolve));
+
+    const invalid = await graphServer({ json: { data: { escrows: [deal({ approved: "false" })] } } });
+    await assert.rejects(() => new GraphAdapter(invalid.endpoint).getDeals("0xseller"), /approved is invalid/);
+    await new Promise((resolve) => invalid.server.close(resolve));
+  });
+
+  it("excludes unresolved and expired refunds from AI judgment counts", async function () {
+    const fixture = [
+      deal({ dealId: "1", id: "1", approved: null, state: "Submitted" }),
+      deal({ dealId: "2", id: "2", approved: null, state: "ExpiredRefund" }),
+      deal({ dealId: "3", id: "3", approved: false, state: "ResolvedRefund" }),
+    ];
+    const server = await graphServer({ json: { data: { escrows: fixture } } });
+    const result = await new GraphAdapter(server.endpoint, undefined, 5000, () => 1000 * 1000).getReputation("0xseller");
+    assert.equal(result.totalDeals, 3);
+    assert.equal(result.totalJudged, 1);
+    assert.equal(result.successes, 0);
+    assert.equal(result.failures, 1);
+    await new Promise((resolve) => server.server.close(resolve));
+  });
+
+  it("rejects malformed required and numeric fields", async function () {
+    for (const override of [{ buyer: undefined }, { amount: "not-a-number" }, { createdAt: "not-a-timestamp" }]) {
+      const server = await graphServer({ json: { data: { escrows: [deal(override)] } } });
+      await assert.rejects(() => new GraphAdapter(server.endpoint).getDeals("0xseller"), /Graph field/);
+      await new Promise((resolve) => server.server.close(resolve));
+    }
+  });
+
+  it("keeps recency deterministic with an injected clock", async function () {
+    const server = await graphServer({ json: { data: { escrows: [deal({ approved: true, createdAt: "900000", updatedAt: "900000" })] } } });
+    const adapter = new GraphAdapter(server.endpoint, undefined, 5000, () => 1_000_000_000);
+    const first = await adapter.getReputation("0xseller");
+    const second = await adapter.getReputation("0xseller");
+    assert.deepEqual(first, second);
+    assert.ok(Number.isFinite(first.recencyWeightedReliability));
+    await new Promise((resolve) => server.server.close(resolve));
+  });
+
+  it("classifies timeout, non-2xx, and GraphQL errors", async function () {
+    const slow = await graphServer({ json: { data: { escrows: [] } } }, 100);
+    await assert.rejects(() => new GraphAdapter(slow.endpoint, undefined, 10).getDeals("0xseller"), (error) => error instanceof GraphUnavailableError && /timed out/.test(error.message));
+    await new Promise((resolve) => slow.server.close(resolve));
+
+    const status = await graphServer({ status: 503, json: { error: "offline" } });
+    await assert.rejects(() => new GraphAdapter(status.endpoint).getDeals("0xseller"), (error) => error instanceof GraphUnavailableError);
+    await new Promise((resolve) => status.server.close(resolve));
+
+    const graphql = await graphServer({ json: { errors: [{ message: "bad query" }] } });
+    await assert.rejects(() => new GraphAdapter(graphql.endpoint).getDeals("0xseller"), /invalid response/);
+    await new Promise((resolve) => graphql.server.close(resolve));
+  });
+});

--- a/mcp-server/test/reputation.test.js
+++ b/mcp-server/test/reputation.test.js
@@ -20,6 +20,8 @@ describe("reputation MCP tool", function () {
   it("returns protocol errors for malformed JSON and unknown methods", async function () {
     const parseError = await invokeMcp("{not-json}\n");
     assert.equal(parseError.error.code, -32700);
+    const invalidRequest = await invokeMcp("null\n");
+    assert.equal(invalidRequest.error.code, -32600);
     const methodError = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 6, method: "not/method" }) + "\n");
     assert.equal(methodError.error.code, -32601);
   });

--- a/mcp-server/test/reputation.test.js
+++ b/mcp-server/test/reputation.test.js
@@ -4,7 +4,38 @@ import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { describe, it } from "mocha";
 
+async function invokeMcp(line, env = {}) {
+  const child = spawn(process.execPath, ["dist/index.js"], {
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const output = [];
+  child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+  child.stdin.end(line);
+  await once(child, "close");
+  return JSON.parse(output.join(""));
+}
+
 describe("reputation MCP tool", function () {
+  it("returns protocol errors for malformed JSON and unknown methods", async function () {
+    const parseError = await invokeMcp("{not-json}\n");
+    assert.equal(parseError.error.code, -32700);
+    const methodError = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 6, method: "not/method" }) + "\n");
+    assert.equal(methodError.error.code, -32601);
+  });
+
+  it("returns structured errors for unknown tools and invalid arguments", async function () {
+    const unknownTool = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 7, method: "tools/call", params: { name: "missing_tool", arguments: {} } }) + "\n");
+    assert.equal(unknownTool.result.isError, true);
+    assert.match(unknownTool.result.structuredContent.error, /Unknown tool/);
+    const invalidArguments = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 8, method: "tools/call", params: { name: "get_agent_reputation", arguments: { agent: "  " } } }) + "\n");
+    assert.equal(invalidArguments.result.isError, true);
+    assert.equal(invalidArguments.result.structuredContent.error, "agent is required");
+    const executionFailure = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "get_agent_reputation", arguments: { agent: "agent-b" } } }) + "\n", { ARBITRA_BACKEND_URL: "http://127.0.0.1:1" });
+    assert.equal(executionFailure.result.isError, true);
+    assert.match(executionFailure.result.structuredContent.error, /fetch failed|Backend reputation request failed/);
+  });
+
   it("returns structured reputation an agent can use for hiring", async function () {
     const http = createServer((request, response) => {
       response.setHeader("Content-Type", "application/json");
@@ -179,5 +210,37 @@ describe("reputation MCP tool", function () {
     const result = JSON.parse(output.join(""));
     assert.equal(result.result.structuredContent.source, "backend");
     assert.equal(result.result.structuredContent.sourceReason, "graph_unavailable");
+  });
+
+  it("returns indexed deal evidence from Graph and keeps audit fallback backend-labeled", async function () {
+    const indexed = createServer((request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ data: { escrow: {
+        id: "0xdeal", dealId: "0xdeal", buyer: "0xbuyer", seller: "0xseller", token: "0xtoken",
+        amount: "100", criteriaHash: "criteria", deadline: "200", state: "ResolvedSuccess", approved: true,
+        createdTransactionHash: "0xcreate", createdBlockNumber: "10", verdictReasoningHash: "0xreasoning",
+      } } }));
+    });
+    indexed.listen(0);
+    await once(indexed, "listening");
+    const indexedAddress = indexed.address();
+    assert.ok(indexedAddress && typeof indexedAddress !== "string");
+    const graphResult = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 10, method: "tools/call", params: { name: "get_indexed_deal", arguments: { dealId: "0xDEAL" } } }) + "\n", { GRAPH_ENDPOINT: `http://127.0.0.1:${indexedAddress.port}` });
+    assert.equal(graphResult.result.structuredContent.source, "graph");
+    assert.equal(graphResult.result.structuredContent.verdictReasoningHash, "0xreasoning");
+    await new Promise((resolve) => indexed.close(resolve));
+
+    const backend = createServer((request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ verified: true, verdictHash: "0xhash", verdict: "PASS" }));
+    });
+    backend.listen(0);
+    await once(backend, "listening");
+    const backendAddress = backend.address();
+    assert.ok(backendAddress && typeof backendAddress !== "string");
+    const fallbackResult = await invokeMcp(JSON.stringify({ jsonrpc: "2.0", id: 11, method: "tools/call", params: { name: "get_indexed_deal", arguments: { dealId: "0xDEAL" } } }) + "\n", { GRAPH_ENDPOINT: "http://127.0.0.1:1", ARBITRA_BACKEND_URL: `http://127.0.0.1:${backendAddress.port}` });
+    assert.equal(fallbackResult.result.structuredContent.source, "backend");
+    assert.equal(fallbackResult.result.structuredContent.sourceReason, "graph_unavailable");
+    await new Promise((resolve) => backend.close(resolve));
   });
 });


### PR DESCRIPTION
## Summary

Hardens the Arbitra end-to-end integration flow and fixes compatibility issues across the AI Judge, backend, escrow manager, audit, and settlement pipeline.

## Changes

* Fixed the event-driven escrow path to pass criteria in the correct `string[]` format to `judgeDeliverable()`.
* Reused the canonical `evaluateDeal()` flow for AI Judge persistence and audit generation.
* Unified the settlement attestation with the canonical `verdictHash`.
* Ensured the same canonical hash is stored in Prisma and submitted to the escrow contract.
* Normalized the escrow deadline conversion for settlement handling.
* Preserved existing AI Judge and IPFS implementations without modifying their internal logic.
* Kept MCP, Graph-backed reputation, audit verification, and fallback behavior compatible with the existing architecture.

## Validation

* MCP tests: 13 passing
* Backend tests: 11 passing
* MCP/backend builds: passed
* Agent simulation: passed
* `git diff --check`: passed
* HIRE / DO NOT HIRE flow verified from MCP-returned reputation data
* Audit verification verified through the canonical backend/Prisma record

## Known Environment Limitations

* Live contract execution is blocked by the existing Node 24 / Hardhat `uv_os_get_passwd` ENOMEM environment issue.
* Live IPFS verification requires Pinata credentials.
* Production The Graph endpoint is not configured locally; Graph behavior was validated with deterministic local mocks.

No frontend, contract, subgraph, or Ali's AI Judge/IPFS implementation was modified.

This PR focuses on making the existing Arbitra demo flow technically consistent and reliable without expanding the product scope.
