### PR TITLE
fix(create): show an error when the seller address is invalid on Store

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -62,7 +62,15 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${grotesk.variable} ${mono.variable}`}>
-      <body className="bg-base text-primary font-sans antialiased">
+      {/* `suppressHydrationWarning` here is narrow and deliberate: it silences the
+          one class of mismatch Next.js itself documents as a false alarm — a
+          browser extension (Dark Reader, in the report this addresses) stamping
+          an attribute like `data-darkreader-proxy-injected` onto `<body>` before
+          React hydrates. React still discards the stray attribute and hydrates
+          correctly; this only stops the console from reporting a divergence that
+          was never in this application's own markup. It does not suppress
+          mismatches inside `children` — only on this element. */}
+      <body className="bg-base text-primary font-sans antialiased" suppressHydrationWarning>
         {/* First in the tab order, off-screen until focused. A keyboard visitor
             should not have to walk the masthead on every route. */}
         <a

--- a/frontend/src/components/CreateDeal.tsx
+++ b/frontend/src/components/CreateDeal.tsx
@@ -99,8 +99,19 @@ export function CreateDeal() {
    * local array, so the digest commits to the bytes that were actually kept. If
    * the store ever normalises anything, this is what keeps the commitment and the
    * record in agreement.
+   *
+   * THE SELLER ADDRESS IS CHECKED HERE TOO, not only inside `sign`. Storing the
+   * criteria is the step right before the two buttons that need a valid seller,
+   * and a reviewer who typed a malformed address and clicked "Store" saw nothing —
+   * the hash still appeared, which reads as the whole form being accepted. `sign`
+   * still validates independently before either signature, since a field can be
+   * edited again after the criteria are stored.
    */
   const store = useCallback(() => {
+    if (!ADDRESS.test(seller.trim())) {
+      setFault({ field: 'seller', message: CREATE.validation.seller });
+      return;
+    }
     if (criteria.length === 0) {
       setFault({ field: 'criteria', message: CREATE.validation.criteria });
       return;
@@ -119,7 +130,7 @@ export function CreateDeal() {
     setUnavailable(null);
     setStored(persisted);
     setCriteriaHash(computeRubricHash({ acceptanceCriteria: [...persisted] }));
-  }, [criteria, dealId]);
+  }, [criteria, dealId, seller]);
 
   /** Validate everything the transaction needs. */
   const validate = useCallback((): { field: FieldName; message: string } | null => {
@@ -213,7 +224,13 @@ export function CreateDeal() {
                 {...props}
                 type="text"
                 value={seller}
-                onChange={(event) => setSeller(event.target.value)}
+                onChange={(event) => {
+                  setSeller(event.target.value);
+                  // The stored criteria hash does not depend on the seller, but the
+                  // fault message beside this field should clear the moment the
+                  // reviewer starts fixing it rather than sitting there stale.
+                  setFault((current) => (current?.field === 'seller' ? null : current));
+                }}
               />
             )}
           </FieldSet>


### PR DESCRIPTION
A teammate flagged this — clicking "Store the criteria" with an invalid seller address gave no error at all, just silently produced the criteria hash. Looked like the app was accepting a bad address.

**Cause:** `validate()` (which checks the seller address) only ran inside `sign()`, reachable only from the Approve / Create-and-fund buttons. Nothing called it from Store.

**Fix:** Store now validates the seller address first, using the same regex `sign` already used, and shows the field error immediately. Editing the seller field afterward clears its stale error.

Also included: the hydration warning shown alongside this report is a separate, unrelated thing — Next's own panel names the cause (`data-darkreader-proxy-injected` stamped by the Dark Reader browser extension before hydration). Added `suppressHydrationWarning` narrowly on `<body>`, which is the documented fix for exactly that case and doesn't hide any real mismatch elsewhere.

`typecheck` clean, 28 tests pass, `check-copy` 0/100, `check-design` 0/94, `next build` green.