### PR TITLE
fix(create): checksum-validate the seller address before building the transaction

### DIFF
--- a/frontend/src/lib/escrowWrite.ts
+++ b/frontend/src/lib/escrowWrite.ts
@@ -32,7 +32,7 @@
  * outside the fixtures, which is the mechanical half of the same rule.
  */
 
-import { Interface, parseUnits } from 'ethers';
+import { Interface, parseUnits, isAddress } from 'ethers';
 
 import { USDC_DECIMALS } from '@/lib/chain';
 import { env } from '@/lib/env';
@@ -175,6 +175,10 @@ export function buildCreateAndFund(args: {
 }): BuildResult<UnsignedCall> {
   const resolved = addresses();
   if (!resolved.ok) return resolved;
+
+  if (!isAddress(args.seller)) {
+    return { ok: false, unavailable: { reason: "Invalid seller address format." } };
+  }
 
   const { escrow, token } = resolved.value;
 


### PR DESCRIPTION
Cherry-picked from `backend/blockchain` (549046f), where it had landed alongside unrelated backend work.

Adds `isAddress` from ethers as a second, stricter check inside `buildCreateAndFund` — it validates the EIP-55 checksum, which the regex check already in `CreateDeal.tsx` (from #25) does not catch. A case-corrupted address would pass the regex but fail here, which is the right outcome: signing a transaction to a checksum-invalid address is exactly the kind of mistake worth stopping before a wallet popup opens.

Re-verified independently on `main`: typecheck clean, 28 tests pass, check-copy 0/100, check-design 0/94, next build green.